### PR TITLE
Refactor Filament Widgets and Enhance Chart Configuration

### DIFF
--- a/app/Filament/Pages/Dashboards/AgentStatsDashboard.php
+++ b/app/Filament/Pages/Dashboards/AgentStatsDashboard.php
@@ -2,12 +2,12 @@
 
 namespace App\Filament\Pages\Dashboards;
 
+use App\Filament\Widgets\Chatwoot\Charts\WorkingMinutesChartWidget;
 use App\Filament\Widgets\Chatwoot\MonthlyMessagesStatsWidget;
 use App\Filament\Widgets\Chatwoot\ResponseTimeChartWidget;
-use App\Filament\Widgets\Chatwoot\WorkingMinutesChartWidget;
 use App\Filament\Widgets\Chatwoot\WorkingTimeStatsWidget;
-use App\Filament\Widgets\Stripe\IssuedInvoiceChartWidget;
-use App\Filament\Widgets\Stripe\ParticipationInvoiceChartWidget;
+use App\Filament\Widgets\Stripe\Charts\IssuedInvoiceChartWidget;
+use App\Filament\Widgets\Stripe\Charts\ParticipationInvoiceChartWidget;
 use App\Models\Chatwoot\Message;
 use App\Models\Filament\User;
 use Arr;

--- a/app/Filament/Widgets/Chatwoot/Charts/WorkHoursChartWidget.php
+++ b/app/Filament/Widgets/Chatwoot/Charts/WorkHoursChartWidget.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Filament\Widgets\Chatwoot;
+namespace App\Filament\Widgets\Chatwoot\Charts;
 
 use App\Traits\Chatwoot\HandlesChatwootStatistics;
 use Carbon\Carbon;
@@ -77,6 +77,18 @@ class WorkHoursChartWidget extends ChartWidget
     protected function getOptions(): array
     {
         return [
+            'scales' => [
+                'x' => [
+                    'grid' => [
+                        'display' => false,
+                    ],
+                ],
+                'y' => [
+                    'grid' => [
+                        'display' => true,
+                    ],
+                ],
+            ],
             'plugins' => [
                 'legend' => [
                     'display' => false,

--- a/app/Filament/Widgets/Chatwoot/Charts/WorkingMinutesChartWidget.php
+++ b/app/Filament/Widgets/Chatwoot/Charts/WorkingMinutesChartWidget.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Filament\Widgets\Chatwoot;
+namespace App\Filament\Widgets\Chatwoot\Charts;
 
 use App\Traits\Chatwoot\HandlesChatwootStatistics;
 use Carbon\Carbon;
@@ -72,6 +72,18 @@ class WorkingMinutesChartWidget extends ChartWidget
     protected function getOptions(): array
     {
         return [
+            'scales' => [
+                'x' => [
+                    'grid' => [
+                        'display' => false,
+                    ],
+                ],
+                'y' => [
+                    'grid' => [
+                        'display' => true,
+                    ],
+                ],
+            ],
             'plugins' => [
                 'legend' => [
                     'display' => false,

--- a/app/Filament/Widgets/Stripe/Charts/IssuedInvoiceChartWidget.php
+++ b/app/Filament/Widgets/Stripe/Charts/IssuedInvoiceChartWidget.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace App\Filament\Widgets\Stripe;
+namespace App\Filament\Widgets\Stripe\Charts;
 
 use App\Traits\Chatwoot\HandlesChatwootStatistics;
+use Carbon\Carbon;
 use Filament\Widgets\ChartWidget;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
-use Carbon\Carbon;
 use Illuminate\Support\Arr;
 
 class IssuedInvoiceChartWidget extends ChartWidget
@@ -57,14 +57,14 @@ class IssuedInvoiceChartWidget extends ChartWidget
         $formattedDatasets = [];
 
         foreach ($statuses as $status => $statusData) {
-            $dataForStatus = array_map(function($currency) use ($statusData) {
+            $dataForStatus = array_map(function ($currency) use ($statusData) {
                 return $statusData[$currency] ?? 0;
             }, $labels);
 
             $formattedDatasets[] = [
                 'label' => ucfirst($status),
                 'data' => $dataForStatus,
-                'stack' => 'stackedBar'
+                'stack' => 'stackedBar',
             ];
         }
 
@@ -82,11 +82,18 @@ class IssuedInvoiceChartWidget extends ChartWidget
     protected function getOptions(): array
     {
         return [
+            'indexAxis' => 'y',
             'scales' => [
                 'x' => [
+                    'grid' => [
+                        'display' => true,
+                    ],
                     'stacked' => true,
                 ],
                 'y' => [
+                    'grid' => [
+                        'display' => false,
+                    ],
                     'stacked' => true,
                 ],
             ],

--- a/app/Filament/Widgets/Stripe/Charts/ParticipationInvoiceChartWidget.php
+++ b/app/Filament/Widgets/Stripe/Charts/ParticipationInvoiceChartWidget.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace App\Filament\Widgets\Stripe;
+namespace App\Filament\Widgets\Stripe\Charts;
 
 use App\Traits\Chatwoot\HandlesChatwootStatistics;
+use Carbon\Carbon;
 use Filament\Widgets\ChartWidget;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
-use Carbon\Carbon;
 use Illuminate\Support\Arr;
 
 class ParticipationInvoiceChartWidget extends ChartWidget
@@ -17,12 +17,14 @@ class ParticipationInvoiceChartWidget extends ChartWidget
     private function getYearFromFilter(): int
     {
         $date = Carbon::parse($this->filters['yearMonth']);
+
         return $date->year;
     }
 
     private function getMonthFromFilter(): int
     {
         $date = Carbon::parse($this->filters['yearMonth']);
+
         return $date->month;
     }
 
@@ -50,10 +52,10 @@ class ParticipationInvoiceChartWidget extends ChartWidget
             }
         }
 
-        $datasets = array_map(function($status) use ($statuses, $labels) {
+        $datasets = array_map(function ($status) use ($statuses, $labels) {
             return [
                 'label' => ucfirst($status),
-                'data' => array_map(fn($currency) => $statuses[$status][$currency] ?? 0, $labels),
+                'data' => array_map(fn ($currency) => $statuses[$status][$currency] ?? 0, $labels),
                 'stack' => 'stackedBar',
             ];
         }, array_keys($statuses));
@@ -72,11 +74,18 @@ class ParticipationInvoiceChartWidget extends ChartWidget
     protected function getOptions(): array
     {
         return [
+            'indexAxis' => 'y',
             'scales' => [
                 'x' => [
+                    'grid' => [
+                        'display' => true,
+                    ],
                     'stacked' => true,
                 ],
                 'y' => [
+                    'grid' => [
+                        'display' => false,
+                    ],
                     'stacked' => true,
                 ],
             ],

--- a/app/Filament/Widgets/Stripe/InvoicesWidget.php
+++ b/app/Filament/Widgets/Stripe/InvoicesWidget.php
@@ -31,10 +31,6 @@ class InvoicesWidget extends Widget implements HasForms, HasInfolists, HasTable
 
     protected int|string|array $columnSpan = 'full';
 
-    protected function paginateTableQuery(Builder $query): CursorPaginator
-    {
-        return $query->cursorPaginate(($this->getTableRecordsPerPage() === 'all') ? $query->count() : $this->getTableRecordsPerPage());
-    }
 
     #[Computed]
     public function getTableQuery()
@@ -49,9 +45,7 @@ class InvoicesWidget extends Widget implements HasForms, HasInfolists, HasTable
 
         return $table
             ->query($this->getTableQuery())
-            ->paginated()
-            ->extremePaginationLinks()
-            ->paginationPageOptions([5])
+            ->paginated(false)
             ->heading('Lista faktur Stripe')
             ->columns([
                 Tables\Columns\TextColumn::make('id')
@@ -92,20 +86,6 @@ class InvoicesWidget extends Widget implements HasForms, HasInfolists, HasTable
                     ->action(function ($data) {
                         $this->createInvoice([$data]);
                     })
-                    ->button()
-                    ->outlined(),
-                ViewAction::make('hostedInvoiceUrlView')
-                    ->label('Pokaż link')
-                    ->icon('heroicon-o-link')
-                    ->form([
-                        Textarea::make('data.hosted_invoice_url')
-                            ->label('Link do faktury')
-                            ->hint('kliknij dwukrotnie lub zaznacz tekst; następnie skopiuj go do schowka'),
-                    ])
-                    ->closeModalByClickingAway()
-                    ->modalCancelAction(false)
-                    ->modalHeading('Link do faktury')
-                    ->modalCloseButton()
                     ->button()
                     ->outlined(),
             ], position: ActionsPosition::AfterColumns);


### PR DESCRIPTION
- Moved `WorkingMinutesChartWidget.php`, `WorkHoursChartWidget.php`, `ParticipationInvoiceChartWidget.php`, and `IssuedInvoiceChartWidget.php` under `Charts` namespace for better organization.
- Updated import paths in `AgentStatsDashboard.php` to reflect the namespace changes.
- Added grid display options to `WorkingMinutesChartWidget`, `WorkHoursChartWidget`, `ParticipationInvoiceChartWidget`, and `IssuedInvoiceChartWidget` to enhance chart configurations.
- Removed unused `paginateTableQuery` method and unnecessary actions from `InvoicesWidget`.

These changes improve code organization and enhance the display options for charts in Filament dashboards and widgets.